### PR TITLE
Use current folder as base directory by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Add to Claude Desktop config:
 
 ### Environment Variables
 
-- `MEMORY_BASE_DIR`: Base directory for all memory categories (default: `./.memory`)
+- `MEMORY_BASE_DIR`: Base directory for all memory categories (default: current working directory)
 - `DEFAULT_CATEGORY`: Default category when none specified (default: `"default"`)
 
 ## Core Concepts

--- a/dist/index.js
+++ b/dist/index.js
@@ -30,7 +30,7 @@ import { fileURLToPath } from 'url';
 import { CategoryManager } from './managers/CategoryManager.js';
 import { KnowledgeGraphManager } from './managers/KnowledgeGraphManager.js';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const MEMORY_BASE_DIR = process.env.MEMORY_BASE_DIR || path.join(__dirname, '..', '.memory');
+const MEMORY_BASE_DIR = process.env.MEMORY_BASE_DIR || process.cwd();
 const DEFAULT_CATEGORY = process.env.DEFAULT_CATEGORY || 'default';
 const categoryManager = new CategoryManager(MEMORY_BASE_DIR);
 const knowledgeGraphManager = new KnowledgeGraphManager(categoryManager, DEFAULT_CATEGORY);

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ import type { Entity, Relation, Observation } from './types/graph.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const MEMORY_BASE_DIR = process.env.MEMORY_BASE_DIR || path.join(__dirname, '..', '.memory');
+const MEMORY_BASE_DIR = process.env.MEMORY_BASE_DIR || process.cwd();
 const DEFAULT_CATEGORY = process.env.DEFAULT_CATEGORY || 'default';
 
 const categoryManager = new CategoryManager(MEMORY_BASE_DIR);


### PR DESCRIPTION
Change MEMORY_BASE_DIR default from path relative to the executable to process.cwd(), so databases are created in the directory where the agent was started rather than where the MCP server is cached.

The env variable MEMORY_BASE_DIR can still be used to override this.